### PR TITLE
fix 原始生命態ニビル

### DIFF
--- a/c27204311.lua
+++ b/c27204311.lua
@@ -36,11 +36,14 @@ function c27204311.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFlagEffect(1-tp,27204311)>=5 and (Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2)
 end
 function c27204311.relfilter(c)
+	return c:IsFaceup()
+end
+function c27204311.relfilter2(c)
 	return c:IsFaceup() and c:IsReleasableByEffect()
 end
 function c27204311.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c27204311.relfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
-	if chk==0 then return g:GetCount()>0 and Duel.GetMZoneCount(tp,g)>0 and Duel.GetMZoneCount(1-tp,g,tp)>0
+	if chk==0 then return g:GetCount()>0
 		and Duel.IsPlayerCanSpecialSummonCount(tp,2)
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false)
 		and Duel.IsPlayerCanSpecialSummonMonster(tp,27204312,0,0x4011,g:GetSum(Card.GetBaseAttack),g:GetSum(Card.GetBaseDefense),11,RACE_ROCK,ATTRIBUTE_LIGHT) end
@@ -48,7 +51,7 @@ function c27204311.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),2,0,0)
 end
 function c27204311.spop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(c27204311.relfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	local g=Duel.GetMatchingGroup(c27204311.relfilter2,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	if g:GetCount()>0 and Duel.Release(g,REASON_EFFECT)~=0 then
 		local og=Duel.GetOperatedGroup()
 		local c=e:GetHandler()


### PR DESCRIPTION
This effect can activate if there are only unreleasable monsters on the field.
If you have used your all Main Monster Zones with the unreleasable monsters（or other unqualified monsters），you also can activate this effect.
According to:
http://yugioh-wiki.net/index.php?cmd=read&page=%A1%D4%B8%B6%BB%CF%C0%B8%CC%BF%C2%D6%A5%CB%A5%D3%A5%EB%A1%D5&word=%B8%B6%BB%CF%C0%B8%CC%BF%C2%D6%A5%CB%A5%D3%A5%EB